### PR TITLE
fix(order): prevent multiple handouts of a blid

### DIFF
--- a/src/bl-error/bl-error-handler.ts
+++ b/src/bl-error/bl-error-handler.ts
@@ -128,6 +128,10 @@ export class BlErrorHandler {
       case 800:
         blapiErrorResponse.msg = "server error";
         break;
+      case 801:
+        blapiErrorResponse.msg = "blid already handed out";
+        blapiErrorResponse.httpStatus = 409;
+        break;
     }
 
     return blapiErrorResponse;

--- a/src/collections/order/operations/place/order-place.operation.ts
+++ b/src/collections/order/operations/place/order-place.operation.ts
@@ -143,11 +143,11 @@ export class OrderPlaceOperation implements Operation {
       "rent",
       "partly-payment",
     ]);
-    const blids = order.orderItems
-      .filter((item) => handoutOrderTypes.has(item.type))
-      .map((orderItem) => orderItem.blid)
-      .filter((blid) => blid != null);
-    if (blids.length === 0) {
+    const handoutItems = order.orderItems.filter(
+      (orderItem) =>
+        handoutOrderTypes.has(orderItem.type) && orderItem.blid != null
+    );
+    if (handoutItems.length === 0) {
       return false;
     }
 
@@ -158,7 +158,7 @@ export class OrderPlaceOperation implements Operation {
         {
           $match: {
             blid: {
-              $in: blids,
+              $in: handoutItems.map((handoutItem) => handoutItem.blid),
             },
             returned: false,
           },

--- a/src/collections/order/operations/place/order-place.operation.ts
+++ b/src/collections/order/operations/place/order-place.operation.ts
@@ -19,6 +19,7 @@ import { OrderPlacedHandler } from "../../helpers/order-placed-handler/order-pla
 import { OrderValidator } from "../../helpers/order-validator/order-validator";
 import { userDetailSchema } from "../../../user-detail/user-detail.schema";
 import { SEDbQueryBuilder } from "../../../../query/se.db-query-builder";
+import { OrderItemType } from "@boklisten/bl-model/dist/order/order-item/order-item-type";
 
 export class OrderPlaceOperation implements Operation {
   private _queryBuilder: SEDbQueryBuilder;
@@ -125,6 +126,53 @@ export class OrderPlaceOperation implements Operation {
     return false;
   }
 
+  /**
+   * Check whether a blid in the order is already handed out
+   *
+   * Unable to check against legacy customeritems which have no blid, but there
+   * are very few of those which are not returned. Only checks whether a blid is
+   * already handed out if the handout order type of the item in this order is
+   * "buy", "rent" or "partly-payment".
+   *
+   * @param order The Order which contains items
+   * @private
+   */
+  private async isSomeBlidAlreadyHandedOut(order: Order): Promise<boolean> {
+    const handoutOrderTypes = new Set<OrderItemType>([
+      "buy",
+      "rent",
+      "partly-payment",
+    ]);
+    const blids = order.orderItems
+      .filter((item) => handoutOrderTypes.has(item.type))
+      .map((orderItem) => orderItem.blid)
+      .filter((blid) => blid != null);
+    if (blids.length === 0) {
+      return false;
+    }
+
+    try {
+      // Use an aggregation because the query builder does not support checking against a list of blids,
+      // and we would otherwise have to send a query for every single order item.
+      const unreturnedItems = await this._customerItemStorage.aggregate([
+        {
+          $match: {
+            blid: {
+              $in: blids,
+            },
+            returned: false,
+          },
+        },
+      ]);
+      return unreturnedItems.length > 0;
+    } catch {
+      console.error(
+        "Could not check whether some items are already handed out"
+      );
+      return false;
+    }
+  }
+
   public async run(
     blApiRequest: BlApiRequest,
     req?: Request,
@@ -145,6 +193,16 @@ export class OrderPlaceOperation implements Operation {
       if (orderContainsActiveCustomerItems) {
         throw new BlError("Order contains active customer items").code(500);
       }
+    }
+
+    const someBlidAlreadyHandedOut = await this.isSomeBlidAlreadyHandedOut(
+      order
+    );
+
+    if (someBlidAlreadyHandedOut) {
+      throw new BlError("Some blid is already handed out to a customer").code(
+        801
+      );
     }
 
     let customerItems: CustomerItem[] = [];


### PR DESCRIPTION
There was already a check to prevent a blid from being added to an order if it already belongs to another order, but if the order had been fulfilled (i.e. the blid handed out), the item could be handed out to another person without first being handed in. This commit fixes that by checking whether some blid in an order is not handed in. In that case, it returns an error with code 801 (409 in the HTTP response).

There are some customeritems which do not have blids, which means we cannot prevent those items from being handed out again. However, some research indicates that these are legacy items of which there are exceedingly few which are not handed in (~55 at time of writing).