### PR TITLE
Update Matches Upon Return And Fix Match Generation Aggregation

### DIFF
--- a/src/bl-error/bl-error-handler.ts
+++ b/src/bl-error/bl-error-handler.ts
@@ -136,6 +136,11 @@ export class BlErrorHandler {
         blapiErrorResponse.msg = "blid already handed out";
         blapiErrorResponse.httpStatus = 409;
         break;
+      case 802:
+        blapiErrorResponse.msg =
+          "some customerItems in this order belong to a UserMatch";
+        blapiErrorResponse.httpStatus = 409;
+        break;
     }
 
     return blapiErrorResponse;


### PR DESCRIPTION
- fix(match-generation): use correct aggregation for senders and receivers
- feat(item return): throw if customerItem part of UserMatch, otherwise update StandMatch with returned item if possible

While working on the logic for updating matches when orders are placed, I noticed I had completely overlooked the aggregation for getting senders and receivers. Using `active: true` is not sufficient at all, we have to use a proper query. (active seems to be true for all customer items 🙃) Therefore, I fixed the aggregations. 🧑‍🔧

Also made some logic to block users from delivering items to stand when those items are are part of a UserMatch.
Lastly, I made logic to update deliveredItems for a standMatch when a match-user delivers an item (of which the item must be part of the StandMatch)