### PR TITLE
fix(order-patch): remove unneccecary check for movedtoOrder

### DIFF
--- a/src/collections/order/helpers/order-item-moved-from-order-handler/order-item-moved-from-order-handler.ts
+++ b/src/collections/order/helpers/order-item-moved-from-order-handler/order-item-moved-from-order-handler.ts
@@ -65,10 +65,11 @@ export class OrderItemMovedFromOrderHandler {
 
     for (const orderItem of originalOrder.orderItems) {
       if (orderItem.item.toString() === orderItemToUpdate.itemId.toString()) {
-        if (orderItem.movedToOrder) {
+        if (!orderItem.movedToOrder) {
+          orderItem.movedToOrder = orderItemToUpdate.newOrderId;
+        } else if (orderItem.movedToOrder !== orderItemToUpdate.newOrderId) {
           throw new BlError(`orderItem has "movedToOrder" already set`);
         }
-        orderItem.movedToOrder = orderItemToUpdate.newOrderId;
       }
     }
 


### PR DESCRIPTION
This blocked you when trying to patch an order, eg. updating the
handoutBranch for instance. This check seems redundant, an in opposition
with the normal patch flow that exists within the other collections.
