### PR TITLE
fix(order-patch): add missing string conversion in comparison

### DIFF
--- a/src/collections/order/helpers/order-item-moved-from-order-handler/order-item-moved-from-order-handler.ts
+++ b/src/collections/order/helpers/order-item-moved-from-order-handler/order-item-moved-from-order-handler.ts
@@ -67,7 +67,9 @@ export class OrderItemMovedFromOrderHandler {
       if (orderItem.item.toString() === orderItemToUpdate.itemId.toString()) {
         if (!orderItem.movedToOrder) {
           orderItem.movedToOrder = orderItemToUpdate.newOrderId;
-        } else if (orderItem.movedToOrder !== orderItemToUpdate.newOrderId) {
+        } else if (
+          String(orderItem.movedToOrder) !== orderItemToUpdate.newOrderId
+        ) {
           throw new BlError(`orderItem has "movedToOrder" already set`);
         }
       }


### PR DESCRIPTION
Needed a `String(orderItem.movedToOrder)` since `orderItem.movedToOrder` is stored and read as an objectID, while `orderItemToUpdate.newOrderId` is a String