### PR TITLE
fix(order): block order generation if userDetails are not present

### DIFF
--- a/src/collections/order/hooks/order.post.hook.spec.ts
+++ b/src/collections/order/hooks/order.post.hook.spec.ts
@@ -135,7 +135,7 @@ describe("OrderPostHook", () => {
 
     it("should reject if requestBody is not valid", () => {
       return expect(
-        orderPostHook.before({ valid: false })
+        orderPostHook.before({ valid: false }, testAccessToken)
       ).to.eventually.be.rejectedWith(BlError, /not a valid order/);
     });
 


### PR DESCRIPTION
This PR implements a hard block on order creation if the customer details are not set. This is just a reassurance for us that our users are not able in some magical way to order, even though the frontend has been updated so that it should not be possible
