### PR TITLE
HOTFIX(moved-to-order): update db sequentially

### DIFF
--- a/src/collections/order/helpers/order-item-moved-from-order-handler/order-item-moved-from-order-handler.ts
+++ b/src/collections/order/helpers/order-item-moved-from-order-handler/order-item-moved-from-order-handler.ts
@@ -34,9 +34,9 @@ export class OrderItemMovedFromOrderHandler {
   private async addMovedToOrderOnOrderItems(
     orderItemsToUpdate: OrderItemToUpdate[],
   ): Promise<boolean> {
-    await Promise.all(
-      orderItemsToUpdate.map((orderItem) => this.updateOrderItem(orderItem)),
-    );
+    for (const orderItemToUpdate of orderItemsToUpdate) {
+      await this.updateOrderItem(orderItemToUpdate);
+    }
     return true;
   }
 


### PR DESCRIPTION
We had a problem updating multiple orders at the same time, since it tried to access and update the same database object at the simultaneously. So essentially, only one went through, and it threw an error, since one of the promises tried to access a locked object. 

Introduced in https://github.com/boklisten/bl-api/pull/464/commits/c7e003f536c9098251fca00c87174dadcddfd225