### PR TITLE
feat(sms): Use custom sender name

### DIFF
--- a/src/messenger/sms/sms-service.ts
+++ b/src/messenger/sms/sms-service.ts
@@ -1,6 +1,5 @@
 import twilio from "twilio";
 
-import { SMS_SETTINGS } from "./sms-settings";
 import { logger } from "../../logger/logger";
 
 const accountSid = process.env.TWILIO_SMS_SID;
@@ -20,7 +19,7 @@ export async function sendSMS(
     await client.messages.create({
       body: message,
       to: `+47${toNumber}`,
-      from: SMS_SETTINGS.fromNumber,
+      from: "Boklisten",
     });
     logger.info(`successfully sent SMS to "${toNumber}"`);
   } catch (e) {

--- a/src/messenger/sms/sms-settings.ts
+++ b/src/messenger/sms/sms-settings.ts
@@ -1,3 +1,0 @@
-export const SMS_SETTINGS = {
-  fromNumber: "+4759447665",
-};


### PR DESCRIPTION
With this setup, we get this:

![image](https://github.com/boklisten/bl-api/assets/26925695/ae7740f6-02f3-4306-b97b-29d4842637eb)
