### PR TITLE
feat(message): add support for custom SMS reminder text

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "@boklisten/bl-email": "^1.7.2",
-    "@boklisten/bl-model": "^0.25.27",
+    "@boklisten/bl-model": "^0.25.28",
     "@boklisten/bl-post-office": "^0.5.53",
     "@sendgrid/mail": "^7.7.0",
     "canvas": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "license": "ISC",
   "dependencies": {
     "@boklisten/bl-email": "^1.7.2",
-    "@boklisten/bl-model": "0.25.26",
-    "@boklisten/bl-post-office": "^0.5.51",
+    "@boklisten/bl-model": "^0.25.27",
+    "@boklisten/bl-post-office": "^0.5.53",
     "@sendgrid/mail": "^7.7.0",
     "canvas": "^2.11.2",
     "commander": "^8.3.0",

--- a/src/auth/local/local-login.validator.spec.ts
+++ b/src/auth/local/local-login.validator.spec.ts
@@ -1,7 +1,6 @@
 import "mocha";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { expect } from "chai";
 import { LocalLoginHandler } from "./local-login.handler";
 import { LocalLogin } from "../../collections/local-login/local-login";
 import { LocalLoginValidator } from "./local-login.validator";
@@ -59,16 +58,12 @@ describe("LocalLoginValidator", () => {
   });
 
   sinon.stub(localLoginHandler, "add").callsFake((localLogin: LocalLogin) => {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       resolve(localLogin);
     });
   });
 
-  sinon
-    .stub(localLoginPasswordValidator, "validate")
-    .callsFake((password: string, salt: string, hashedPassword: any) => {
-      return Promise.resolve(true);
-    });
+  sinon.stub(localLoginPasswordValidator, "validate").resolves(true);
 
   sinon
     .stub(userHandler, "create")
@@ -91,7 +86,7 @@ describe("LocalLoginValidator", () => {
     });
 
   sinon.stub(userHandler, "valid").callsFake(() => {
-    return Promise.resolve(true);
+    return Promise.resolve();
   });
 
   describe("validate()", () => {

--- a/src/auth/token/token.handler.spec.ts
+++ b/src/auth/token/token.handler.spec.ts
@@ -5,9 +5,6 @@ import sinon from "sinon";
 import { TokenHandler } from "./token.handler";
 import { BlError } from "@boklisten/bl-model";
 import { UserHandler } from "../user/user.handler";
-import { TokenConfig } from "./token.config";
-import { AccessToken } from "./access-token/access-token";
-import { RefreshToken } from "./refresh/refresh-token";
 
 chai.use(chaiAsPromised);
 
@@ -25,28 +22,7 @@ const testUser: any = {
 };
 
 describe("TokenHandler", () => {
-  const refreshTokenConfig: RefreshToken = {
-    iss: "",
-    aud: "",
-    expiresIn: "12h",
-    iat: 0,
-    sub: "",
-    username: "",
-  };
-
-  const accessTokenConfig: AccessToken = {
-    iss: "",
-    aud: "",
-    expiresIn: "30s",
-    iat: 0,
-    sub: "",
-    username: "",
-    permission: "customer",
-    details: "",
-  };
-
   const userHandler = new UserHandler();
-  const tokenConfig = new TokenConfig(accessTokenConfig, refreshTokenConfig);
   const tokenHandler = new TokenHandler(userHandler);
 
   sinon.stub(userHandler, "getByUsername").callsFake((username: string) => {
@@ -59,7 +35,7 @@ describe("TokenHandler", () => {
   });
 
   sinon.stub(userHandler, "valid").callsFake(() => {
-    return Promise.resolve(true);
+    return Promise.resolve();
   });
 
   describe("createTokens()", () => {

--- a/src/auth/user/user-provider/user-provider.spec.ts
+++ b/src/auth/user/user-provider/user-provider.spec.ts
@@ -1,15 +1,14 @@
-import "mocha";
+import { BlError } from "@boklisten/bl-model";
 
-import chai from "chai";
+import chai, { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
+import "mocha";
 import sinon from "sinon";
-import { expect } from "chai";
-import { UserHandler } from "../user.handler";
-import { BlError, UserDetail } from "@boklisten/bl-model";
-import { User } from "../../../collections/user/user";
-import { UserProvider } from "./user-provider";
 import { LocalLoginHandler } from "../../local/local-login.handler";
 import { TokenHandler } from "../../token/token.handler";
+import { UserHandler } from "../user.handler";
+import { UserProvider } from "./user-provider";
+
 chai.use(chaiAsPromised);
 
 describe("UserProvider", () => {
@@ -51,7 +50,7 @@ describe("UserProvider", () => {
 
     it("should reject if localLoginHandler.createDefaultLocalLoginIfNoneIsFound rejects", () => {
       userGetStub.resolves({ id: "user1" } as any);
-      userValidStub.resolves(true);
+      userValidStub.resolves();
       createDefaultLocalLoginStub.rejects(
         new BlError("local login could not be created"),
       );
@@ -78,7 +77,7 @@ describe("UserProvider", () => {
         const user = {};
         userGetStub.rejects(new BlError("user not found"));
         userCreateStub.resolves(user as any);
-        userValidStub.resolves(true);
+        userValidStub.resolves();
         createDefaultLocalLoginStub.resolves(true);
         const tokens = { accessToken: "atoken", refreshToken: "rtoken" };
         createTokenStub.resolves(tokens);
@@ -93,7 +92,7 @@ describe("UserProvider", () => {
       it("should resolve with a user object and tokens", () => {
         const user = { id: "user1", username: "user@mail.com" };
         userGetStub.resolves(user as any);
-        userValidStub.resolves(true);
+        userValidStub.resolves();
         createDefaultLocalLoginStub.resolves(true);
 
         const tokens = { accessToken: "atoken", refreshToken: "rtoken" };

--- a/src/auth/user/user.handler.spec.ts
+++ b/src/auth/user/user.handler.spec.ts
@@ -61,33 +61,25 @@ describe("UserHandler", () => {
 
   const emailValidationHelperSendLinkStub = sinon
     .stub(emailValidationHelper, "createAndSendEmailValidationLink")
-    .callsFake((userDetailId: string) => {
+    .callsFake(() => {
       if (!emailValidationLinkSuccess) {
         return Promise.reject(
           new BlError("could not create and send email validation"),
         );
       }
 
-      return Promise.resolve(true);
+      return Promise.resolve();
     });
 
   sinon.stub(userDetailStorage, "add").callsFake(() => {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       resolve({ id: testUser.userDetail, user: { id: testUser.blid } } as any);
     });
   });
 
-  sinon.stub(userStorage, "add").callsFake((data: any, user: any) => {
-    return new Promise((resolve, reject) => {
-      resolve(testUser);
-    });
-  });
+  sinon.stub(userStorage, "add").resolves(testUser);
 
-  const localLoginHandlerGetStub = sinon
-    .stub(localLoginHandler, "get")
-    .callsFake(() => {
-      return Promise.resolve({} as LocalLogin);
-    });
+  sinon.stub(localLoginHandler, "get").resolves({} as LocalLogin);
 
   const userStorageGetByQueryStub = sinon
     .stub(userStorage, "getByQuery")

--- a/src/auth/user/user.handler.ts
+++ b/src/auth/user/user.handler.ts
@@ -166,7 +166,7 @@ export class UserHandler {
     if (!providerId || providerId.length <= 0)
       throw new BlError("providerId is empty or undefined").code(907);
 
-    let userExists: User = null;
+    let userExists: User;
     try {
       userExists = await this.getByUsername(username);
     } catch (e) {
@@ -257,12 +257,9 @@ export class UserHandler {
     );
   }
 
-  private sendEmailValidationLink(userDetail: UserDetail): Promise<boolean> {
-    return this._emailValidationHelper
+  private async sendEmailValidationLink(userDetail: UserDetail): Promise<void> {
+    await this._emailValidationHelper
       .createAndSendEmailValidationLink(userDetail.id)
-      .then(() => {
-        return true;
-      })
       .catch((sendEmailValidationLinkError: BlError) => {
         throw new BlError("could not send out email validation link").add(
           sendEmailValidationLinkError,
@@ -270,7 +267,7 @@ export class UserHandler {
       });
   }
 
-  public valid(username: string): Promise<boolean> {
+  public valid(username: string): Promise<void> {
     return new Promise((resolve, reject) => {
       this.getByUsername(username)
         .then((user: User) => {
@@ -278,7 +275,7 @@ export class UserHandler {
             return reject(new BlError("user.active is false").code(913));
           }
 
-          resolve(true);
+          resolve();
         })
         .catch((getUserError: BlError) => {
           reject(getUserError);
@@ -286,7 +283,7 @@ export class UserHandler {
     });
   }
 
-  public exists(provider: string, providerId: string): Promise<boolean> {
+  public exists(provider: string, providerId: string): Promise<void> {
     if (!provider || !providerId) {
       return Promise.reject(
         new BlError("provider or providerId is empty or undefinedl"),
@@ -302,9 +299,8 @@ export class UserHandler {
     return new Promise((resolve, reject) => {
       this.userStorage
         .getByQuery(dbQuery)
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        .then((users: User[]) => {
-          resolve(true);
+        .then(() => {
+          resolve();
         })
         .catch((blError: BlError) => {
           reject(new BlError("does not exist").add(blError));

--- a/src/bl-error/bl-error-handler.ts
+++ b/src/bl-error/bl-error-handler.ts
@@ -168,6 +168,11 @@ export class BlErrorHandler {
           "Ordren inneholder bøker som er låst til en UserMatch; kunden må motta de låste bøkene fra en annen elev";
         blapiErrorResponse.httpStatus = 409;
         break;
+      case 808:
+        blapiErrorResponse.msg =
+          "Kan ikke sende e-post-påminnelse med egendefinert tekst, bare SMS";
+        blapiErrorResponse.httpStatus = 400;
+        break;
     }
 
     return blapiErrorResponse;

--- a/src/collections/email-validation/helpers/email-validation.helper.spec.ts
+++ b/src/collections/email-validation/helpers/email-validation.helper.spec.ts
@@ -57,7 +57,7 @@ describe("EmailValidationHelper", () => {
 
   const messengerEmailConfirmationStub = sinon
     .stub(messenger, "emailConfirmation")
-    .callsFake(() => {});
+    .resolves();
 
   describe("#createAndSendEmailValidationLink", () => {
     it("should reject if userId is not found", () => {

--- a/src/collections/email-validation/hooks/email-validation-post.hook.spec.ts
+++ b/src/collections/email-validation/hooks/email-validation-post.hook.spec.ts
@@ -35,7 +35,7 @@ describe("EmailValidationPostHook", () => {
       );
     }
 
-    return Promise.resolve(true);
+    return Promise.resolve();
   });
 
   describe("#after", () => {

--- a/src/collections/message/hooks/message-post.hook.ts
+++ b/src/collections/message/hooks/message-post.hook.ts
@@ -57,8 +57,13 @@ export class MessagePostHook extends Hook {
     switch (message.messageType) {
       case "custom-reminder":
       case "reminder":
-        if (message.messageType === "custom-reminder" && message.messageMethod !== "sms") {
-          throw new BlError("Cannot send custom email reminder, only SMS").code(808)
+        if (
+          message.messageType === "custom-reminder" &&
+          message.messageMethod !== "sms"
+        ) {
+          throw new BlError("Cannot send custom email reminder, only SMS").code(
+            808,
+          );
         }
         return await this.onRemind(message);
       case "generic":

--- a/src/collections/message/hooks/message-post.hook.ts
+++ b/src/collections/message/hooks/message-post.hook.ts
@@ -55,7 +55,11 @@ export class MessagePostHook extends Hook {
     }
 
     switch (message.messageType) {
+      case "custom-reminder":
       case "reminder":
+        if (message.messageType === "custom-reminder" && message.messageMethod !== "sms") {
+          throw new BlError("Cannot send custom email reminder, only SMS").code(808)
+        }
         return await this.onRemind(message);
       case "generic":
         return await this.onGeneric(message);

--- a/src/collections/order/helpers/order-placed-handler/order-placed-handler.spec.ts
+++ b/src/collections/order/helpers/order-placed-handler/order-placed-handler.spec.ts
@@ -93,18 +93,16 @@ describe("OrderPlacedHandler", () => {
     return Promise.resolve([testPayment]);
   });
 
-  sinon.stub(orderStorage, "update").callsFake((id: string, data: any) => {
+  sinon.stub(orderStorage, "update").callsFake(() => {
     if (!orderUpdate) {
       return Promise.reject(new BlError("could not update order"));
     }
     return Promise.resolve(testOrder);
   });
 
-  const getOrderStub = sinon.stub(orderStorage, "get");
+  sinon.stub(orderStorage, "get");
 
-  sinon.stub(messenger, "orderPlaced").callsFake(() => {
-    return true;
-  });
+  sinon.stub(messenger, "orderPlaced").resolves();
 
   beforeEach(() => {
     paymentsConfirmed = true;

--- a/src/messenger/email/email-service.ts
+++ b/src/messenger/email/email-service.ts
@@ -193,12 +193,13 @@ export class EmailService implements MessengerService {
     );
 
     const messageOptions: MessageOptions = {
-      type: "reminder",
+      type: message.messageType,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       subtype: message.messageSubtype as any,
       sequence_number: message.sequenceNumber,
       textBlocks: message.textBlocks,
       mediums: this.getMessageOptionMediums(message),
+      customContent: message.customContent,
     };
 
     try {

--- a/src/messenger/email/order-email/order-email-handler.spec.ts
+++ b/src/messenger/email/order-email/order-email-handler.spec.ts
@@ -16,7 +16,6 @@ import { BlDocumentStorage } from "../../../storage/blDocumentStorage";
 import { OrderEmailHandler } from "./order-email-handler";
 import { dateService } from "../../../blc/date.service";
 import { EmailHandler, EmailLog } from "@boklisten/bl-email";
-import { isNullOrUndefined } from "util";
 import moment from "moment-timezone";
 import { BlCollectionName } from "../../../collections/bl-collection";
 
@@ -85,7 +84,7 @@ describe("OrderEmailHandler", () => {
 
       return expect(
         orderEmailHandler.sendOrderReceipt(testCustomerDetail, testOrder),
-      ).to.be.rejectedWith(Error, /could not send email/);
+      ).to.be.rejectedWith(Error, /Unable to send order receipt email/);
     });
 
     it("should resolve with EmailLog if emailHandler.sendWithAgreement resolves", () => {
@@ -172,29 +171,28 @@ describe("OrderEmailHandler", () => {
           branchStorageGetStub
             .withArgs(testOrder.branch as string)
             .resolves({ paymentInfo: { responsible: true } } as Branch);
-          (testCustomerDetail.dob = moment(new Date())
+          testCustomerDetail.dob = moment(new Date())
             .subtract(16, "year")
-            .toDate()),
-            orderEmailHandler
-              .sendOrderReceipt(testCustomerDetail, testOrder)
-              .then(() => {
-                const sendOrderReceiptArguments =
-                  sendOrderReceiptStub.getCalls();
+            .toDate();
+          orderEmailHandler
+            .sendOrderReceipt(testCustomerDetail, testOrder)
+            .then(() => {
+              const sendOrderReceiptArguments = sendOrderReceiptStub.getCalls();
 
-                const guardianEmailSetting =
-                  sendOrderReceiptArguments[
-                    sendOrderReceiptStub.getCalls().length - 2
-                  ].args[0]; // the next to last call should be to the guardian
+              const guardianEmailSetting =
+                sendOrderReceiptArguments[
+                  sendOrderReceiptStub.getCalls().length - 2
+                ].args[0]; // the next to last call should be to the guardian
 
-                expect(guardianEmailSetting.toEmail).to.be.eq(
-                  testCustomerDetail.guardian.email,
-                );
+              expect(guardianEmailSetting.toEmail).to.be.eq(
+                testCustomerDetail.guardian.email,
+              );
 
-                done();
-              })
-              .catch((err) => {
-                done(err);
-              });
+              done();
+            })
+            .catch((err) => {
+              done(err);
+            });
         });
       });
 

--- a/src/messenger/email/order-email/order-email-handler.ts
+++ b/src/messenger/email/order-email/order-email-handler.ts
@@ -93,12 +93,13 @@ export class OrderEmailHandler {
       this.addNoPaymentProvidedNotice(emailSetting);
     }
 
-    return this._emailHandler.sendOrderReceipt(
-      emailSetting,
-      emailOrder,
-      emailUser,
-      withAgreement,
-    );
+    return await this._emailHandler
+      .sendOrderReceipt(emailSetting, emailOrder, emailUser, withAgreement)
+      .catch((e) => {
+        throw new BlError("Unable to send order receipt email")
+          .code(200)
+          .add(e);
+      });
   }
 
   private paymentNeeded(order: Order): boolean {

--- a/src/messenger/email/order-email/order-email-handler.ts
+++ b/src/messenger/email/order-email/order-email-handler.ts
@@ -342,9 +342,10 @@ export class OrderEmailHandler {
         : null,
       trackingNumber: delivery.info["trackingNumber"],
       estimatedDeliveryDate: delivery.info["estimatedDelivery"]
-        ? moment(delivery.info["estimatedDelivery"])
-            .utcOffset(this.utcOffset)
-            .format(this.standardDayFormat)
+        ? dateService.toPrintFormat(
+            delivery.info["estimatedDelivery"],
+            "Europe/Oslo",
+          )
         : "",
     };
   }

--- a/src/messenger/messenger.ts
+++ b/src/messenger/messenger.ts
@@ -1,3 +1,4 @@
+import { EmailAttachment } from "@boklisten/bl-email";
 import {
   Delivery,
   Order,
@@ -17,9 +18,9 @@ import { deliverySchema } from "../collections/delivery/delivery.schema";
 import { BlDocumentStorage } from "../storage/blDocumentStorage";
 
 export class Messenger implements MessengerService {
-  private _emailService: EmailService;
-  private _pdfService: PdfService;
-  private _deliveryStorage: BlDocumentStorage<Delivery>;
+  private readonly _emailService: EmailService;
+  private readonly _pdfService: PdfService;
+  private readonly _deliveryStorage: BlDocumentStorage<Delivery>;
 
   constructor() {
     this._emailService = new EmailService();
@@ -32,11 +33,14 @@ export class Messenger implements MessengerService {
 
   /**
    * send out message(s) to the customer
-   * @param {Message[]} messages
+   * @param {Message[]} message
    * @param {UserDetail} customerDetail
    */
-  public send(message: Message, customerDetail: UserDetail) {
-    this._emailService.send(message, customerDetail);
+  public async send(
+    message: Message,
+    customerDetail: UserDetail,
+  ): Promise<void> {
+    await this._emailService.send(message, customerDetail);
   }
 
   /**
@@ -44,31 +48,35 @@ export class Messenger implements MessengerService {
    * @param {Message[]} messages
    * @param {UserDetail[]} customerDetails
    */
-  public sendMany(messages: Message[], customerDetails: UserDetail[]) {
-    this._emailService.sendMany(messages, customerDetails);
+  public async sendMany(
+    messages: Message[],
+    customerDetails: UserDetail[],
+  ): Promise<void> {
+    await this._emailService.sendMany(messages, customerDetails);
   }
 
   /**
    * reminds the customer of the due date of his items
-   * @param {UserDetail} the customer to send reminder to
-   * @param {CustomerItem[]} the customerItems to remind of
+   * @param message the message to send
+   * @param customerDetail the customer to send reminder to
+   * @param customerItems the customerItems to remind of
    */
-  public remind(
+  public async remind(
     message: Message,
     customerDetail: UserDetail,
     customerItems: CustomerItem[],
-  ) {
-    this._emailService.remind(message, customerDetail, customerItems);
+  ): Promise<void> {
+    await this._emailService.remind(message, customerDetail, customerItems);
   }
 
   /**
    * sends out reminders to more than one customer
-   * @param {CustomerDetailWithCustomerItem[]} customerDetails with customerItems to remind about
+   * @param customerDetailsWithCustomerItems customerDetails with customerItems to remind about
    */
-  public remindMany(
+  public async remindMany(
     customerDetailsWithCustomerItems: CustomerDetailWithCustomerItem[],
-  ) {
-    this._emailService.remindMany(customerDetailsWithCustomerItems);
+  ): Promise<void> {
+    await this._emailService.remindMany(customerDetailsWithCustomerItems);
   }
 
   /**
@@ -76,8 +84,11 @@ export class Messenger implements MessengerService {
    * @param {UserDetail} customerDetail
    * @param {Order} order
    */
-  public orderPlaced(customerDetail: UserDetail, order: Order) {
-    this._emailService.orderPlaced(customerDetail, order);
+  public async orderPlaced(
+    customerDetail: UserDetail,
+    order: Order,
+  ): Promise<void> {
+    await this._emailService.orderPlaced(customerDetail, order);
   }
 
   /**
@@ -85,8 +96,11 @@ export class Messenger implements MessengerService {
    * @param {UserDetail} customerDetail
    * @param {Order} order
    */
-  public getOrderReceiptPdf(customerDetail: UserDetail, order: Order) {
-    return this._pdfService.getOrderReceiptPdf(customerDetail, order);
+  public async getOrderReceiptPdf(
+    customerDetail: UserDetail,
+    order: Order,
+  ): Promise<EmailAttachment> {
+    return await this._pdfService.getOrderReceiptPdf(customerDetail, order);
   }
 
   /**
@@ -94,19 +108,24 @@ export class Messenger implements MessengerService {
    * @param {UserDetail} customerDetail
    * @param {Order} order
    */
-  public getOrderAgreementPdf(customerDetail: UserDetail, order: Order) {
-    return this._pdfService.getOrderAgreementPdf(customerDetail, order);
+  public async getOrderAgreementPdf(
+    customerDetail: UserDetail,
+    order: Order,
+  ): Promise<EmailAttachment> {
+    return await this._pdfService.getOrderAgreementPdf(customerDetail, order);
   }
 
-  public sendDeliveryInformation(customerDetail: UserDetail, order: Order) {
+  public async sendDeliveryInformation(
+    customerDetail: UserDetail,
+    order: Order,
+  ): Promise<void> {
     const deliveryId = typeof order.delivery === "string" ? order.delivery : "";
-    this._deliveryStorage
-      .get(deliveryId)
-      .then((delivery: Delivery) => {
-        this._emailService.deliveryInformation(customerDetail, order, delivery);
-      })
-      // eslint-disable-next-line @typescript-eslint/no-empty-function
-      .catch(() => {});
+    const delivery = await this._deliveryStorage.get(deliveryId);
+    await this._emailService.deliveryInformation(
+      customerDetail,
+      order,
+      delivery,
+    );
   }
 
   /**
@@ -114,11 +133,14 @@ export class Messenger implements MessengerService {
    * @param {UserDetail} customerDetail
    * @param {string} confirmationCode
    */
-  public emailConfirmation(
+  public async emailConfirmation(
     customerDetail: UserDetail,
     confirmationCode: string,
-  ) {
-    this._emailService.emailConfirmation(customerDetail, confirmationCode);
+  ): Promise<void> {
+    await this._emailService.emailConfirmation(
+      customerDetail,
+      confirmationCode,
+    );
   }
 
   /**

--- a/src/messenger/reminder/messenger-reminder.ts
+++ b/src/messenger/reminder/messenger-reminder.ts
@@ -7,48 +7,44 @@ import { BlDocumentStorage } from "../../storage/blDocumentStorage";
 import { EmailService } from "../email/email-service";
 
 export class MessengerReminder {
-  private customerItemHandler: CustomerItemHandler;
-  private userDetailStorage: BlDocumentStorage<UserDetail>;
-  private emailService: EmailService;
+  private readonly customerItemHandler: CustomerItemHandler;
+  private readonly userDetailStorage: BlDocumentStorage<UserDetail>;
+  private readonly emailService: EmailService;
 
   constructor(
     customerItemHandler?: CustomerItemHandler,
     userDetailStorage?: BlDocumentStorage<UserDetail>,
     emailService?: EmailService,
   ) {
-    this.customerItemHandler = customerItemHandler
-      ? customerItemHandler
-      : new CustomerItemHandler();
-    this.userDetailStorage = userDetailStorage
-      ? userDetailStorage
-      : new BlDocumentStorage<UserDetail>(
-          BlCollectionName.UserDetails,
-          userDetailSchema,
-        );
-    this.emailService = emailService ? emailService : new EmailService();
+    this.customerItemHandler = customerItemHandler ?? new CustomerItemHandler();
+    this.userDetailStorage =
+      userDetailStorage ??
+      new BlDocumentStorage<UserDetail>(
+        BlCollectionName.UserDetails,
+        userDetailSchema,
+      );
+    this.emailService = emailService ?? new EmailService();
   }
 
   /**
    *  Tries to remind all customers to return items that have the specified deadline
    *  @param deadline the deadline the reminder is for
    */
-  // eslint-disable-next-line
-  public remindAll(deadline: Date) {}
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public remindAll(deadline: Date) {
+    throw new BlError("Not implemented!").code(200);
+  }
 
   /**
    *  Reminds a customer to return a item with the specified deadline
-   *  @param customerId the customers id
-   *  @param deadline the deadline the reminder is for
-   *  @param messageId if provided, stores message info in that message object
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public async remindCustomer(message: Message): Promise<any> {
+  public async remindCustomer(message: Message): Promise<void> {
     if (message.customerId == null || message.customerId.length <= 0) {
-      throw new BlError("customerId is null or undefined");
+      throw new BlError("customerId is null or undefined").code(701);
     }
 
     if (!message.info || message.info["deadline"] == null) {
-      throw new BlError("deadline is null or undefined");
+      throw new BlError("deadline is null or undefined").code(701);
     }
 
     const notReturnedCustomerItems =
@@ -66,7 +62,5 @@ export class MessengerReminder {
       userDetail,
       notReturnedCustomerItems,
     );
-
-    return true;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,17 +21,17 @@
     puppeteer "^9.1.1"
     typescript "^2.6.2"
 
-"@boklisten/bl-model@0.25.26":
-  version "0.25.26"
-  resolved "https://registry.yarnpkg.com/@boklisten/bl-model/-/bl-model-0.25.26.tgz#324091873a80deb62b064dde4de2e9bb426b6acb"
-  integrity sha512-KpChYWqWcNob73KEhXucOI0cyQKQ7zI2cwIt4PEAe9VFF/LJwavwn9jwRvcrcN45qX3huCUguf2yABK9zJ62Bg==
+"@boklisten/bl-model@^0.25.27":
+  version "0.25.27"
+  resolved "https://registry.yarnpkg.com/@boklisten/bl-model/-/bl-model-0.25.27.tgz#26ba29538a09f381f1d55bb424c24ccbf71933ef"
+  integrity sha512-PfdcAWyb66GMvpX/J1r7kJjEVSFmUbwhcJ+ncDU8EAR7ZPtNTs+M7MxEbEk8dIFqlRaOgHWoYo0z53l4s2roaA==
   dependencies:
     typescript "^5.2.2"
 
-"@boklisten/bl-post-office@^0.5.51":
-  version "0.5.51"
-  resolved "https://registry.yarnpkg.com/@boklisten/bl-post-office/-/bl-post-office-0.5.51.tgz#4a57401a371877ce84f4abc7784c476b465dcb0d"
-  integrity sha512-kfQO3o3WV0vD+ztKR9wwLB5Ny1VbNomyhkQ4NrLGtNWRd1FhHdOUyfcXbtuZKQihRfA4qR2/wJq+eG++KWQeag==
+"@boklisten/bl-post-office@^0.5.53":
+  version "0.5.53"
+  resolved "https://registry.yarnpkg.com/@boklisten/bl-post-office/-/bl-post-office-0.5.53.tgz#c5f016cee7bda895092e9883d146932b1e624c00"
+  integrity sha512-qF94DulYX8WopEmzvZ1AFqWR7W8rnUB1IXyXgVr2EmhWXA7u8WNoHvPYG+9kaWXY1y8bXue5hyFQQ2tWNEWcpg==
   dependencies:
     "@sendgrid/mail" "^6.3.1"
     "@types/mustache" "^0.8.32"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,10 +21,10 @@
     puppeteer "^9.1.1"
     typescript "^2.6.2"
 
-"@boklisten/bl-model@^0.25.27":
-  version "0.25.27"
-  resolved "https://registry.yarnpkg.com/@boklisten/bl-model/-/bl-model-0.25.27.tgz#26ba29538a09f381f1d55bb424c24ccbf71933ef"
-  integrity sha512-PfdcAWyb66GMvpX/J1r7kJjEVSFmUbwhcJ+ncDU8EAR7ZPtNTs+M7MxEbEk8dIFqlRaOgHWoYo0z53l4s2roaA==
+"@boklisten/bl-model@^0.25.28":
+  version "0.25.28"
+  resolved "https://registry.yarnpkg.com/@boklisten/bl-model/-/bl-model-0.25.28.tgz#561f2c0a9ffa0e3c0126993e11251c113cf779f9"
+  integrity sha512-3tTJiHO1uK/8934TChqEOuBz4urOr/yeoS6B1zVljg345+yoYNAlDB/mGyfYfByV5Fh8haaxdOifn3vpjyAZjw==
   dependencies:
     typescript "^5.2.2"
 


### PR DESCRIPTION
- refactor: improve signatures and patterns of message code
- refactor: improve signatures and patterns of message code
- chore: fix randomly failing test by unifying date formatting
- fix(message-post-hook): move sending to before() to only log successful messages
- feat: enable custom SMS reminder text

![image](https://github.com/boklisten/bl-api/assets/6224384/a6af3e0e-f912-43f2-bbd8-2f302a1b090d)
