### PR TITLE
fix(customer-item.schema): reintroduce default false values

### DIFF
--- a/src/collections/customer-item/customer-item.schema.ts
+++ b/src/collections/customer-item/customer-item.schema.ts
@@ -30,7 +30,10 @@ export const customerItemSchema = new Schema<CustomerItem>({
     id: Schema.Types.ObjectId,
     time: Date,
   },
-  handout: Boolean,
+  handout: {
+    type: Boolean,
+    default: false,
+  },
   handoutInfo: {
     handoutBy: {
       type: String,
@@ -53,17 +56,26 @@ export const customerItemSchema = new Schema<CustomerItem>({
     returnEmployee: Schema.Types.ObjectId,
     time: Date,
   },
-  cancel: Boolean,
+  cancel: {
+    type: Boolean,
+    default: false,
+  },
   cancelInfo: {
     order: Schema.Types.ObjectId,
     time: Date,
   },
-  buyout: Boolean,
+  buyout: {
+    type: Boolean,
+    default: false,
+  },
   buyoutInfo: {
     order: Schema.Types.ObjectId,
     time: Date,
   },
-  buyback: Boolean,
+  buyback: {
+    type: Boolean,
+    default: false,
+  },
   buybackInfo: {
     order: Schema.Types.ObjectId,
   },


### PR DESCRIPTION
The fact that these values are not initialized as "false" makes some queries not work anymore (since we have queries checking whether these are exlicitly equal to "false", not falsey. Therefore, we need to set these to "false" by default. We also need to apply these defaults to the items in the database that don't have these