### PR TITLE
HOTFIX(invoice): add missing payment field to schema

### DIFF
--- a/src/collections/invoice/invoice.schema.ts
+++ b/src/collections/invoice/invoice.schema.ts
@@ -83,6 +83,7 @@ export const invoiceSchema = new Schema<Invoice>({
         vat: Number,
         discount: Number,
       },
+      totalIncludingFee: Number,
     },
     required: true,
   },


### PR DESCRIPTION
When we updated Mongoose, it now simply did not add this field as it was not part of the schema. (as it should)