### PR TITLE
build: use correct dist path

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "ts-node-dev ./src/index.ts",
     "build": "tsc -p tsconfig.build.json",
-    "serve": "node ./dist/src/index.js",
+    "serve": "node ./dist/index.js",
     "prettier": "prettier --write . --ignore-path=.gitignore",
     "prettier:check": "prettier --check . --ignore-path=.gitignore",
     "lint": "eslint .",


### PR DESCRIPTION
The strict mode TS PR changed the output of the compilation. I was foolish and did not actually build and serve 🤷🏻 