### PR TITLE
HOTFIX(http.handler): remove String conversion of response body

### DIFF
--- a/src/http/http.handler.ts
+++ b/src/http/http.handler.ts
@@ -9,7 +9,7 @@ const request = require("request");
 const rp = require("request-promise");
 
 export class HttpHandler {
-  post(url: string, data: unknown, authorization?: string): Promise<string> {
+  post(url: string, data: unknown, authorization?: string): Promise<unknown> {
     return new Promise((resolve, reject) => {
       const options = {
         url: url,
@@ -32,7 +32,7 @@ export class HttpHandler {
 
         if (res && res.statusCode) {
           if (res.statusCode == 200 || res.statusCode === 201) {
-            return resolve(String(body));
+            return resolve(body);
           }
 
           logger.verbose(`<-R ERROR ${err}`);

--- a/src/payment/dibs/dibs-payment.service.ts
+++ b/src/payment/dibs/dibs-payment.service.ts
@@ -37,7 +37,7 @@ export class DibsPaymentService {
           dibsEasyOrder,
           process.env["DIBS_SECRET_KEY"],
         )
-        .then((responseData: string) => {
+        .then((responseData) => {
           if (responseData) {
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment
             // @ts-ignore


### PR DESCRIPTION
This caused payments to fail, as the response was just [Object object] due to the String() conversion. This caused payments to break... 