### PR TITLE
fix(match-operation): add missing pending signature field

### DIFF
--- a/src/collections/match/operations/match-operation-utils.ts
+++ b/src/collections/match/operations/match-operation-utils.ts
@@ -87,6 +87,7 @@ export async function createMatchOrder(
     branch: branch.id,
     customer: userDetailId,
     byCustomer: true,
+    pendingSignature: false,
     orderItems: [
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore


### PR DESCRIPTION
Once the item is transferred, they will have signed anyway, as ordering books makes you sign. We might handle the case where a minor orders and then the guardian does not sign before the match transfer on a later occasion.
