### PR TITLE
feat(order): update user matches on stand handout/-in

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,16 +15,12 @@
     "emitDecoratorMetadata": true,
 
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "exactOptionalPropertyTypes": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
-    "allowUnusedLabels": false,
-    "allowUnreachableCode": false,
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
- **feat(match): change scan feedback**
- **ci(tsconfig): don't error on unused**
- **feat(order): update user matches on handout/-in**

When user matches are unlocked, the books should be shown as properly
handed out/in when the stand takes care of it. Therefore, when the stand
hands out a book, if the receiver was supposed to get it through a
UserMatch, that match will update to show he received the item. However,
the sender who was supposed to deliver it will get the usual warning
that he has to deliver his book even though someone else gave the
receiver a book. Similarly, when the stand accepts a book, if the sender
was supposed to deliver it through a UserMatch, it will update the match
to show that it was delivered. However, the receiver will still see that
they need to get the book.

What is shown when the sender has handed in at stand, and receiver has not received anything:
![Stand handed in](https://github.com/boklisten/bl-api/assets/6224384/032b93b2-d727-4253-a086-5593838f36b2)



What is shown when the receiver has picked up at stand, and sender has not handed in anything:
![Stand handed out](https://github.com/boklisten/bl-api/assets/6224384/6fcaf233-db27-427e-a8db-fdb0a97f0ff7)



What is shown when both receiver and sender have picked up or handed off the relevant book at stand:
![Stand handed out and in](https://github.com/boklisten/bl-api/assets/6224384/795b4384-77d9-45dd-96b1-b4db790ebfc4)

