### PR TITLE
Use Query Params Instead of Parm Map for auth/token

### DIFF
--- a/src/response/se.response.handler.ts
+++ b/src/response/se.response.handler.ts
@@ -26,7 +26,7 @@ export class SEResponseHandler {
   ) {
     const redirectUrl = `${
       referer ?? process.env["CLIENT_URI"]
-    }auth/token;accessToken=${accessToken};refreshToken=${refreshToken}`;
+    }auth/token?access_token=${accessToken}&refresh_token=${refreshToken}`;
     res.redirect(redirectUrl);
   }
 


### PR DESCRIPTION
We need to use proper query params for the eventual bl-next switch. This is a prepatory step to enable the switch.