### PR TITLE
Setup SendGrid Templates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,15 +9,15 @@ jobs:
   install:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "yarn"
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Cache install
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./node_modules/
           key: ${{ github.sha }}-install
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: install
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Retrive install cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./node_modules/
           key: ${{ github.sha }}-install
@@ -39,9 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: install
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Retrive install cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./node_modules/
           key: ${{ github.sha }}-install
@@ -52,9 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: install
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Retrive install cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./node_modules/
           key: ${{ github.sha }}-install
@@ -65,9 +65,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: install
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Retrive Install Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./node_modules/
           key: ${{ github.sha }}-install

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prettier": "prettier --write . --ignore-path=.gitignore",
     "prettier:check": "prettier --check . --ignore-path=.gitignore",
     "lint": "eslint .",
-    "test": "mocha \"src/**/*.spec.ts\" -r dotenv/config",
+    "test": "NODE_ENV=test mocha \"src/**/*.spec.ts\"",
     "load_fixtures": "mongodb-fixtures rebuild -u mongodb://127.0.0.1:27017/test"
   },
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prettier": "prettier --write . --ignore-path=.gitignore",
     "prettier:check": "prettier --check . --ignore-path=.gitignore",
     "lint": "eslint .",
-    "test": "NODE_ENV=test mocha \"src/**/*.spec.ts\"",
+    "test": "mocha \"src/**/*.spec.ts\" -r dotenv/config",
     "load_fixtures": "mongodb-fixtures rebuild -u mongodb://127.0.0.1:27017/test"
   },
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prettier": "prettier --write . --ignore-path=.gitignore",
     "prettier:check": "prettier --check . --ignore-path=.gitignore",
     "lint": "eslint .",
-    "test": "mocha \"src/**/*.spec.ts\"",
+    "test": "NODE_ENV=test mocha \"src/**/*.spec.ts\"",
     "load_fixtures": "mongodb-fixtures rebuild -u mongodb://127.0.0.1:27017/test"
   },
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@boklisten/bl-model": "^0.26.2",
     "@boklisten/bl-post-office": "^0.5.56",
     "@napi-rs/image": "^1.8.0",
-    "@sendgrid/mail": "^7.7.0",
+    "@sendgrid/mail": "^8.1.3",
     "canvas": "^2.11.2",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",

--- a/src/auth/facebook/facebook.auth.ts
+++ b/src/auth/facebook/facebook.auth.ts
@@ -5,6 +5,7 @@ import { Profile, Strategy, StrategyOptions } from "passport-facebook";
 
 import { APP_CONFIG } from "../../application-config";
 import { ApiPath } from "../../config/api-path";
+import { assertEnv, BlEnvironment } from "../../config/environment";
 import { SEResponseHandler } from "../../response/se.response.handler";
 import { UserProvider } from "../user/user-provider/user-provider";
 
@@ -20,10 +21,10 @@ export class FacebookAuth {
     this.apiPath = new ApiPath();
 
     this.facebookPassportStrategySettings = {
-      clientID: process.env["FACEBOOK_CLIENT_ID"] ?? "",
-      clientSecret: process.env["FACEBOOK_SECRET"] ?? "",
+      clientID: assertEnv(BlEnvironment.FACEBOOK_CLIENT_ID),
+      clientSecret: assertEnv(BlEnvironment.FACEBOOK_SECRET),
       callbackURL:
-        process.env["BL_API_URI"] +
+        assertEnv(BlEnvironment.BL_API_URI) +
         this.apiPath.createPath("auth/facebook/callback"),
       profileFields: ["id", "email", "name"],
       enableProof: true,
@@ -98,7 +99,7 @@ export class FacebookAuth {
           (err, tokens, blError: BlError) => {
             if (!tokens && (err || blError)) {
               return res.redirect(
-                process.env["CLIENT_URI"] +
+                assertEnv(BlEnvironment.CLIENT_URI) +
                   APP_CONFIG.path.client.auth.socialLoginFailure,
               );
             }

--- a/src/auth/google/google.auth.ts
+++ b/src/auth/google/google.auth.ts
@@ -1,10 +1,11 @@
 import { BlError } from "@boklisten/bl-model";
 import { Router } from "express";
 import passport from "passport";
-import { Strategy as GoogleStrategy, Profile } from "passport-google-oauth20";
+import { Profile, Strategy as GoogleStrategy } from "passport-google-oauth20";
 
 import { APP_CONFIG } from "../../application-config";
 import { ApiPath } from "../../config/api-path";
+import { assertEnv, BlEnvironment } from "../../config/environment";
 import { SEResponseHandler } from "../../response/se.response.handler";
 import { UserProvider } from "../user/user-provider/user-provider";
 
@@ -28,11 +29,11 @@ export class GoogleAuth {
     passport.use(
       new GoogleStrategy(
         {
-          clientID: process.env["GOOGLE_CLIENT_ID"] ?? "",
-          clientSecret: process.env["GOOGLE_SECRET"] ?? "",
+          clientID: assertEnv(BlEnvironment.GOOGLE_CLIENT_ID),
+          clientSecret: assertEnv(BlEnvironment.GOOGLE_SECRET),
           passReqToCallback: true,
           callbackURL:
-            process.env["BL_API_URI"] +
+            assertEnv(BlEnvironment.BL_API_URI) +
             this.apiPath.createPath("auth/google/callback"),
         },
         async (req, accessToken, refreshToken, profile, done) => {
@@ -95,7 +96,7 @@ export class GoogleAuth {
 
           if (!tokens && (err || blError)) {
             return res.redirect(
-              process.env["CLIENT_URI"] +
+              assertEnv(BlEnvironment.CLIENT_URI) +
                 APP_CONFIG.path.client.auth.socialLoginFailure,
             );
           }

--- a/src/auth/token/access-token/access-token.secret.ts
+++ b/src/auth/token/access-token/access-token.secret.ts
@@ -1,5 +1,7 @@
+import { assertEnv, BlEnvironment } from "../../../config/environment";
+
 export class AccessTokenSecret {
   public get(): string {
-    return process.env["ACCESS_TOKEN_SECRET"] ?? "hello this is dog";
+    return assertEnv(BlEnvironment.ACCESS_TOKEN_SECRET);
   }
 }

--- a/src/auth/token/refresh/refresh-token.secret.ts
+++ b/src/auth/token/refresh/refresh-token.secret.ts
@@ -1,7 +1,7 @@
+import { assertEnv, BlEnvironment } from "../../../config/environment";
+
 export class RefreshTokenSecret {
   get(): string {
-    return (
-      process.env["REFRESH_TOKEN_SECRET"] ?? "secretly a string is just chars"
-    );
+    return assertEnv(BlEnvironment.REFRESH_TOKEN_SECRET);
   }
 }

--- a/src/collections/delivery/helpers/deliveryBring/bringDelivery.service.ts
+++ b/src/collections/delivery/helpers/deliveryBring/bringDelivery.service.ts
@@ -3,6 +3,7 @@ import moment from "moment";
 
 import { BringDelivery } from "./bringDelivery";
 import { APP_CONFIG } from "../../../../application-config";
+import { assertEnv, BlEnvironment } from "../../../../config/environment";
 import { isNullish } from "../../../../helper/typescript-helpers";
 import { HttpHandler } from "../../../../http/http.handler";
 
@@ -58,8 +59,8 @@ export class BringDeliveryService {
     }
 
     const bringAuthHeaders = {
-      "X-MyBring-API-Key": process.env["BRING_API_KEY"],
-      "X-MyBring-API-Uid": process.env["BRING_API_ID"],
+      "X-MyBring-API-Key": assertEnv(BlEnvironment.BRING_API_KEY),
+      "X-MyBring-API-Uid": assertEnv(BlEnvironment.BRING_API_ID),
     };
 
     const postalInfoUrl = `https://api.bring.com/pickuppoint/api/postalCode/NO/getCityAndType/${shipmentAddress.postalCode}.json`;

--- a/src/collections/delivery/operations/postal-code-lookup.operation.ts
+++ b/src/collections/delivery/operations/postal-code-lookup.operation.ts
@@ -1,5 +1,6 @@
 import { BlapiResponse, BlError } from "@boklisten/bl-model";
 
+import { assertEnv, BlEnvironment } from "../../../config/environment";
 import { isNullish } from "../../../helper/typescript-helpers";
 import { HttpHandler } from "../../../http/http.handler";
 import { Operation } from "../../../operation/operation";
@@ -47,8 +48,8 @@ export class PostalCodeLookupOperation implements Operation {
       throw new BlError(`Malformed PostalCodeSpec`).code(701);
     }
     const bringAuthHeaders = {
-      "X-MyBring-API-Key": process.env["BRING_API_KEY"],
-      "X-MyBring-API-Uid": process.env["BRING_API_ID"],
+      "X-MyBring-API-Key": assertEnv(BlEnvironment.BRING_API_KEY),
+      "X-MyBring-API-Uid": assertEnv(BlEnvironment.BRING_API_ID),
     };
     try {
       const response = (await this.httpHandler.getWithQuery(

--- a/src/config/api-path.ts
+++ b/src/config/api-path.ts
@@ -1,24 +1,21 @@
 import { IncomingHttpHeaders } from "http";
 
+import { BlEnvironment, assertEnv } from "./environment";
 import { APP_CONFIG } from "../application-config";
 
 export class ApiPath {
   private readonly baseHost: string;
 
   constructor() {
-    if (process.env["NODE_ENV"] == "production") {
+    if (assertEnv(BlEnvironment.NODE_ENV) === "production") {
       this.baseHost = APP_CONFIG.path.host;
     } else {
       this.baseHost = APP_CONFIG.path.local.host;
     }
   }
 
-  private getBasePath(): string {
-    return process.env["SERVER_PATH"] ?? "";
-  }
-
   public createPath(customPath: string): string {
-    return this.getBasePath() + customPath;
+    return assertEnv(BlEnvironment.SERVER_PATH) + customPath;
   }
 
   public retrieveRefererPath(reqHeaders: IncomingHttpHeaders) {

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -30,20 +30,14 @@ export enum BlEnvironment {
  *
  *
  * @param key the environment variable key
- * @param callback optional callback that runs if the environment variable is present, and we are not in a test
- * @returns the value of the environment variable if the environment variable is present, and we are not in a test
+ * @returns the value of the environment variable if the environment variable is present
  *
- * @throws BlError if the environment variable is not present, and we are not in a test
+ * @throws BlError if the environment variable is not present
  */
-export function assertEnv(
-  key: BlEnvironment,
-  callback?: (value: string) => unknown,
-): string {
+export function assertEnv(key: BlEnvironment): string {
   const value = process.env[key];
-  if (process.env[BlEnvironment.NODE_ENV] === "test") return "placeholder";
   if (isNullish(value)) {
     throw new BlError(`${key} is a required environment variable`).code(200);
   }
-  callback?.(value);
   return value;
 }

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -1,0 +1,49 @@
+import { BlError } from "@boklisten/bl-model";
+
+import { isNullish } from "../helper/typescript-helpers";
+
+export enum BlEnvironment {
+  PORT = "PORT",
+  SERVER_PATH = "SERVER_PATH",
+  NODE_ENV = "NODE_ENV",
+  LOG_LEVEL = "LOG_LEVEL",
+  URI_WHITELIST = "URI_WHITELIST",
+  ACCESS_TOKEN_SECRET = "ACCESS_TOKEN_SECRET",
+  REFRESH_TOKEN_SECRET = "REFRESH_TOKEN_SECRET",
+  BL_API_URI = "BL_API_URI",
+  CLIENT_URI = "CLIENT_URI",
+  MONGODB_URI = "MONGODB_URI",
+  DIBS_SECRET_KEY = "DIBS_SECRET_KEY",
+  DIBS_URI = "DIBS_URI",
+  FACEBOOK_CLIENT_ID = "FACEBOOK_CLIENT_ID",
+  FACEBOOK_SECRET = "FACEBOOK_SECRET",
+  GOOGLE_CLIENT_ID = "GOOGLE_CLIENT_ID",
+  GOOGLE_SECRET = "GOOGLE_SECRET",
+  SENDGRID_API_KEY = "SENDGRID_API_KEY",
+  TWILIO_SMS_AUTH_TOKEN = "TWILIO_SMS_AUTH_TOKEN",
+  TWILIO_SMS_SID = "TWILIO_SMS_SID",
+  BRING_API_KEY = "BRING_API_KEY",
+  BRING_API_ID = "BRING_API_ID",
+}
+
+/**
+ *
+ *
+ * @param key the environment variable key
+ * @param callback optional callback that runs if the environment variable is present, and we are not in a test
+ * @returns the value of the environment variable if the environment variable is present, and we are not in a test
+ *
+ * @throws BlError if the environment variable is not present, and we are not in a test
+ */
+export function assertEnv(
+  key: BlEnvironment,
+  callback?: (value: string) => unknown,
+): string {
+  const value = process.env[key];
+  if (process.env[BlEnvironment.NODE_ENV] === "test") return "placeholder";
+  if (isNullish(value)) {
+    throw new BlError(`${key} is a required environment variable`).code(200);
+  }
+  callback?.(value);
+  return value;
+}

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -26,16 +26,25 @@ export enum BlEnvironment {
   BRING_API_ID = "BRING_API_ID",
 }
 
+const testPlaceHolders: {
+  [key in BlEnvironment]?: string;
+} = {
+  [BlEnvironment.SENDGRID_API_KEY]: "SG.placeholder",
+  [BlEnvironment.TWILIO_SMS_SID]: "AC.placeholder",
+};
+
 /**
  *
  *
  * @param key the environment variable key
- * @returns the value of the environment variable if the environment variable is present
+ * @returns the value of the environment variable if the environment variable is present, and we are not in a test
  *
- * @throws BlError if the environment variable is not present
+ * @throws BlError if the environment variable is not present, and we are not in a test
  */
 export function assertEnv(key: BlEnvironment): string {
   const value = process.env[key];
+  if (process.env[BlEnvironment.NODE_ENV] === "test")
+    return testPlaceHolders[key] ?? "placeholder";
   if (isNullish(value)) {
     throw new BlError(`${key} is a required environment variable`).code(200);
   }

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -1,6 +1,8 @@
 import moment from "moment";
 import { createLogger, format, transports } from "winston";
 
+import { assertEnv, BlEnvironment } from "../config/environment";
+
 function formatTimestamp(timestamp: string) {
   return moment(timestamp).format("HH:mm:ss.SSS");
 }
@@ -19,10 +21,8 @@ export const logger = createLogger({
   format: format.combine(
     format.printf((info) => {
       const colorizer = format.colorize();
-      if (
-        process.env["NODE_ENV"] === "production" ||
-        process.env["NODE_ENV"] === "dev"
-      ) {
+      const nodeEnv = assertEnv(BlEnvironment.NODE_ENV);
+      if (nodeEnv === "production" || nodeEnv === "dev") {
         return `${info.level} ${info.message}`;
       }
       return colorizer.colorize(
@@ -31,12 +31,12 @@ export const logger = createLogger({
       );
     }),
     format.colorize({
-      all: process.env["NODE_ENV"] !== "production",
+      all: assertEnv(BlEnvironment.NODE_ENV) !== "production",
     }),
   ),
   transports: [
     new transports.Console({
-      level: process.env["LOG_LEVEL"] ?? "info",
+      level: assertEnv(BlEnvironment.LOG_LEVEL),
       handleExceptions: true,
     }),
   ],

--- a/src/messenger/email/email-service.ts
+++ b/src/messenger/email/email-service.ts
@@ -45,7 +45,7 @@ export class EmailService implements MessengerService {
     itemStorage?: BlDocumentStorage<Item>,
     inputPostOffice?: PostOffice,
   ) {
-    assertEnv(BlEnvironment.SENDGRID_API_KEY, (v) => sgMail.setApiKey(v));
+    sgMail.setApiKey(assertEnv(BlEnvironment.SENDGRID_API_KEY));
     this._emailHandler = emailHandler
       ? emailHandler
       : new EmailHandler({

--- a/src/messenger/email/email-settings.ts
+++ b/src/messenger/email/email-settings.ts
@@ -8,6 +8,7 @@ export const EMAIL_SETTINGS = {
       fromEmail: "ikkesvar@boklisten.no",
       subject: "Bekreft e-posten din hos Boklisten.no",
       path: "auth/email/confirm/",
+      templateId: "d-8734d0fdf5fc4d99bf22553c3a0c724a",
     },
     passwordReset: {
       fromEmail: "ikkesvar@boklisten.no",

--- a/src/messenger/sms/sms-service.ts
+++ b/src/messenger/sms/sms-service.ts
@@ -1,17 +1,17 @@
-import twilio, { Twilio } from "twilio";
+import twilio from "twilio";
 
 import { assertEnv, BlEnvironment } from "../../config/environment";
 import { logger } from "../../logger/logger";
 
-let client: Twilio;
-assertEnv(BlEnvironment.TWILIO_SMS_SID, (accountSid) =>
-  assertEnv(BlEnvironment.TWILIO_SMS_AUTH_TOKEN, (authToken) => {
-    client = twilio(accountSid, authToken, {
-      autoRetry: true,
-      maxRetries: 5,
-    });
-  }),
+const client = twilio(
+  assertEnv(BlEnvironment.TWILIO_SMS_SID),
+  assertEnv(BlEnvironment.TWILIO_SMS_AUTH_TOKEN),
+  {
+    autoRetry: true,
+    maxRetries: 5,
+  },
 );
+
 /**
  * Send a single SMS to a single recipient
  * @param toNumber Norwegian phone number (without country code)

--- a/src/messenger/sms/sms-service.ts
+++ b/src/messenger/sms/sms-service.ts
@@ -1,14 +1,17 @@
-import twilio from "twilio";
+import twilio, { Twilio } from "twilio";
 
+import { assertEnv, BlEnvironment } from "../../config/environment";
 import { logger } from "../../logger/logger";
 
-const accountSid = process.env["TWILIO_SMS_SID"];
-const authToken = process.env["TWILIO_SMS_AUTH_TOKEN"];
-const client = twilio(accountSid ?? "ACSid", authToken ?? "authToken", {
-  autoRetry: true,
-  maxRetries: 5,
-});
-
+let client: Twilio;
+assertEnv(BlEnvironment.TWILIO_SMS_SID, (accountSid) =>
+  assertEnv(BlEnvironment.TWILIO_SMS_AUTH_TOKEN, (authToken) => {
+    client = twilio(accountSid, authToken, {
+      autoRetry: true,
+      maxRetries: 5,
+    });
+  }),
+);
 /**
  * Send a single SMS to a single recipient
  * @param toNumber Norwegian phone number (without country code)

--- a/src/payment/dibs/dibs-payment.service.ts
+++ b/src/payment/dibs/dibs-payment.service.ts
@@ -12,6 +12,7 @@ import { DibsEasyOrder } from "./dibs-easy-order/dibs-easy-order";
 import { DibsEasyPayment } from "./dibs-easy-payment/dibs-easy-payment";
 import { APP_CONFIG } from "../../application-config";
 import { UserDetailHelper } from "../../collections/user-detail/helpers/user-detail.helper";
+import { assertEnv, BlEnvironment } from "../../config/environment";
 import { HttpHandler } from "../../http/http.handler";
 import { BlDocumentStorage } from "../../storage/blDocumentStorage";
 
@@ -33,9 +34,9 @@ export class DibsPaymentService {
     return new Promise((resolve, reject) => {
       this._httpHandler
         .post(
-          process.env["DIBS_URI"] + APP_CONFIG.path.dibs.payment,
+          assertEnv(BlEnvironment.DIBS_URI) + APP_CONFIG.path.dibs.payment,
           dibsEasyOrder,
-          process.env["DIBS_SECRET_KEY"],
+          assertEnv(BlEnvironment.DIBS_SECRET_KEY),
         )
         .then((responseData) => {
           if (responseData) {
@@ -60,11 +61,11 @@ export class DibsPaymentService {
   public fetchDibsPaymentData(paymentId: string): Promise<DibsEasyPayment> {
     return this._httpHandler
       .get(
-        process.env["DIBS_URI"] +
+        assertEnv(BlEnvironment.DIBS_URI) +
           APP_CONFIG.path.dibs.payment +
           "/" +
           paymentId,
-        process.env["DIBS_SECRET_KEY"],
+        assertEnv(BlEnvironment.DIBS_SECRET_KEY),
       )
       .then((response) => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -109,10 +110,10 @@ export class DibsPaymentService {
 
     const userDetailValid = this._userDetailHelper.isValid(userDetail);
 
+    const clientUri = assertEnv(BlEnvironment.CLIENT_URI);
     dibsEasyOrder.checkout = {
-      url: process.env["CLIENT_URI"] + APP_CONFIG.path.client.checkout,
-      termsUrl:
-        process.env["CLIENT_URI"] + APP_CONFIG.path.client.agreement.rent,
+      url: clientUri + APP_CONFIG.path.client.checkout,
+      termsUrl: clientUri + APP_CONFIG.path.client.agreement.rent,
       ShippingCountries: [{ countryCode: "NOR" }],
       merchantHandlesConsumerData: userDetailValid, // if userDetail is not valid, the customer must reenter data
       consumer: userDetailValid

--- a/src/response/se.response.handler.ts
+++ b/src/response/se.response.handler.ts
@@ -2,6 +2,7 @@ import { BlapiResponse, BlapiErrorResponse } from "@boklisten/bl-model";
 import { Response } from "express";
 
 import { BlErrorHandler } from "../bl-error/bl-error-handler";
+import { BlEnvironment, assertEnv } from "../config/environment";
 import { logger } from "../logger/logger";
 
 export class SEResponseHandler {
@@ -25,7 +26,7 @@ export class SEResponseHandler {
     referer?: string,
   ) {
     const redirectUrl = `${
-      referer ?? process.env["CLIENT_URI"]
+      referer ?? assertEnv(BlEnvironment.CLIENT_URI)
     }auth/token?access_token=${accessToken}&refresh_token=${refreshToken}`;
     res.redirect(redirectUrl);
   }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,7 +1,5 @@
 // IMPORTANT TO KEEP THIS ON TOP
-// eslint-disable-next-line import/order
-import dotenv from "dotenv";
-dotenv.config(); //adds the .env file to environment variables
+import "dotenv/config";
 
 import path from "path";
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -17,6 +17,7 @@ import passport from "passport";
 
 import { BlAuth } from "../auth/bl.auth";
 import { CollectionEndpointCreator } from "../collection-endpoint/collection-endpoint-creator";
+import { assertEnv, BlEnvironment } from "../config/environment";
 import { logger } from "../logger/logger";
 
 export class Server {
@@ -59,9 +60,8 @@ export class Server {
 
   private connectToMongoDb(): Promise<boolean> {
     return new Promise((resolve, reject) => {
-      logger.verbose(
-        `trying to connect to mongodb: ${process.env["MONGODB_URI"]}`,
-      );
+      const mongoUri = assertEnv(BlEnvironment.MONGODB_URI);
+      logger.verbose(`trying to connect to mongodb: ${mongoUri}`);
 
       mongoose.connection.on("disconnected", () => {
         logger.error("mongoose connection was disconnected");
@@ -76,13 +76,13 @@ export class Server {
       });
 
       mongoose
-        .connect(process.env["MONGODB_URI"] ?? "", {
+        .connect(mongoUri, {
           maxPoolSize: 10,
           connectTimeoutMS: 10000,
           socketTimeoutMS: 45000,
         })
         .then(() => {
-          logger.verbose(`connected to mongodb: ${process.env["MONGODB_URI"]}`);
+          logger.verbose(`connected to mongodb: ${mongoUri}`);
           resolve(true);
         })
         .catch((err) => {
@@ -100,7 +100,7 @@ export class Server {
           (reason instanceof Error ? `, stack: ${reason.stack}` : ""),
       );
     });
-    const whitelist = process.env["URI_WHITELIST"]?.split(" ");
+    const whitelist = assertEnv(BlEnvironment.URI_WHITELIST).split(" ");
     const allowedMethods = ["GET", "PUT", "PATCH", "POST", "DELETE"];
     const allowedHeaders = [
       "Content-Type",
@@ -117,7 +117,9 @@ export class Server {
     };
 
     this.app.use(
-      process.env["API_ENV"] === "staging" ? cors() : cors(corsConfig),
+      assertEnv(BlEnvironment.NODE_ENV) === "production"
+        ? cors(corsConfig)
+        : cors(),
     );
     this.app.use(cookieParser() as RequestHandler);
     this.app.use(passport.initialize() as RequestHandler);
@@ -129,7 +131,8 @@ export class Server {
         logger.debug(`-> ${req.method} ${req.url}`);
         if (
           !(
-            req.url.includes("auth") && process.env["NODE_ENV"] === "production"
+            req.url.includes("auth") &&
+            assertEnv(BlEnvironment.NODE_ENV) === "production"
           )
         ) {
           let body: string;
@@ -148,7 +151,7 @@ export class Server {
     this.app.get("*", (req, res, next) => {
       if (
         req.headers["x-forwarded-proto"] !== "https" &&
-        process.env["NODE_ENV"] === "production"
+        assertEnv(BlEnvironment.NODE_ENV) === "production"
       ) {
         res.redirect("https://" + req.hostname + req.url);
       } else {
@@ -180,7 +183,7 @@ export class Server {
   }
 
   private serverStart() {
-    this.app.set("port", process.env["PORT"] ?? 1337);
+    this.app.set("port", assertEnv(BlEnvironment.PORT));
 
     // eslint-disable-next-line import/no-named-as-default-member
     this.app.use(express.static(path.join(__dirname, "../public")));
@@ -214,7 +217,5 @@ export class Server {
     logger.silly(" | |_) | | (_| | |_) | |");
     logger.silly(" |_.__/|_|\\__,_| .__/|_|");
     logger.silly("               |_|");
-
-    logger.verbose("mongoDB path:\t" + process.env["MONGODB_URI"]);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -299,13 +299,13 @@
     "@types/request" "^2.48.4"
     request "^2.88.0"
 
-"@sendgrid/client@^7.7.0":
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-7.7.0.tgz#f8f67abd604205a0d0b1af091b61517ef465fdbf"
-  integrity sha512-SxH+y8jeAQSnDavrTD0uGDXYIIkFylCo+eDofVmZLQ0f862nnqbC3Vd1ej6b7Le7lboyzQF6F7Fodv02rYspuA==
+"@sendgrid/client@^8.1.3":
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-8.1.3.tgz#51fd4a318627c4b615ff98e35609e98486a3bd6f"
+  integrity sha512-mRwTticRZIdUTsnyzvlK6dMu3jni9ci9J+dW/6fMMFpGRAJdCJlivFVYQvqk8kRS3RnFzS7sf6BSmhLl1ldDhA==
   dependencies:
-    "@sendgrid/helpers" "^7.7.0"
-    axios "^0.26.0"
+    "@sendgrid/helpers" "^8.0.0"
+    axios "^1.6.8"
 
 "@sendgrid/helpers@^6.5.5":
   version "6.5.5"
@@ -315,10 +315,10 @@
     chalk "^2.0.1"
     deepmerge "^4.2.2"
 
-"@sendgrid/helpers@^7.7.0":
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/@sendgrid/helpers/-/helpers-7.7.0.tgz#93fb4b6e2f0dc65080440d6a784cc93e8e148757"
-  integrity sha512-3AsAxfN3GDBcXoZ/y1mzAAbKzTtUZ5+ZrHOmWQ279AuaFXUNCh9bPnRpN504bgveTqoW+11IzPg3I0WVgDINpw==
+"@sendgrid/helpers@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@sendgrid/helpers/-/helpers-8.0.0.tgz#f74bf9743bacafe4c8573be46166130c604c0fc1"
+  integrity sha512-Ze7WuW2Xzy5GT5WRx+yEv89fsg/pgy3T1E3FS0QEx0/VvRmigMZ5qyVGhJz4SxomegDkzXv/i0aFPpHKN8qdAA==
   dependencies:
     deepmerge "^4.2.2"
 
@@ -330,13 +330,13 @@
     "@sendgrid/client" "^6.5.5"
     "@sendgrid/helpers" "^6.5.5"
 
-"@sendgrid/mail@^7.7.0":
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-7.7.0.tgz#aba09f5ce2e9d8ceee92284c3ea8b4a90b0e38fe"
-  integrity sha512-5+nApPE9wINBvHSUxwOxkkQqM/IAAaBYoP9hw7WwgDNQPxraruVqHizeTitVtKGiqWCKm2mnjh4XGN3fvFLqaw==
+"@sendgrid/mail@^8.1.3":
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-8.1.3.tgz#d371cbddcd2e8ca9469a68d1ed0c6b3a5c365e5e"
+  integrity sha512-Wg5iKSUOER83/cfY6rbPa+o3ChnYzWwv1OcsR8gCV8SKi+sUPIMroildimlnb72DBkQxcbylxng1W7f0RIX7MQ==
   dependencies:
-    "@sendgrid/client" "^7.7.0"
-    "@sendgrid/helpers" "^7.7.0"
+    "@sendgrid/client" "^8.1.3"
+    "@sendgrid/helpers" "^8.0.0"
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -1203,12 +1203,21 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^0.26.0, axios@^0.26.1:
+axios@^0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
   integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
   dependencies:
     follow-redirects "^1.14.8"
+
+axios@^1.6.8:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.7.2.tgz#b625db8a7051fbea61c35a3cbb3a1daa7b9c7621"
+  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-runtime@^6.9.2:
   version "6.26.0"
@@ -2973,6 +2982,11 @@ follow-redirects@^1.14.8:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
+follow-redirects@^1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
+  integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
 fontkit@^1.8.1:
   version "1.9.0"


### PR DESCRIPTION
- **refactor(dotenv): use esm import**
- **feat(email-service): setup email templates**

This PR sets up email templating, using SendGrid Dynamic Templates. This means that we can generate the emails in the SendGrid GUI editor, and insert variables, attachments or custom HTML if need be. This approach can let us get rid of bl-email _really_ quickly, as I just made our first template in like 5 minutes, for the email confirmation page. This design is quite simple tho, and we can for sure make something really pretty with their tooling.

## Current confirm email template
<img width="647" alt="Screenshot 2024-07-06 at 15 47 12" src="https://github.com/boklisten/bl-api/assets/26925695/85f896ab-c8d8-473e-85c8-63f5222a4a19">

## The new one (I just copied over everything to SendGrid)
<img width="647" alt="Screenshot 2024-07-06 at 15 45 26" src="https://github.com/boklisten/bl-api/assets/26925695/8e5b141d-4b0a-4d97-8138-4d9073fc3d90">
